### PR TITLE
Add pyopenssl to requirements

### DIFF
--- a/requirment.txt
+++ b/requirment.txt
@@ -1,6 +1,6 @@
 xmltodict
 cigam
 pyelftools
-OpenSSL
+pyopenssl
 anytree
 TextWizard


### PR DESCRIPTION
To use the OpenSSL library one should install the pyopenssl module.

```
$ pip install -r requirment.txt
ERROR: Could not find a version that satisfies the requirement OpenSSL (from -r requirment.txt (line 4)) (from versions: none)
ERROR: No matching distribution found for OpenSSL (from -r requirment.txt (line 4))
```