### PR TITLE
fix: 使用header里的偏移查找entries，而非假设数据是连续的

### DIFF
--- a/apkutils/__init__.py
+++ b/apkutils/__init__.py
@@ -12,7 +12,6 @@ from apkutils.dex.dexparser import DexFile
 from cigam import Magic
 from TextWizard import hash
 
-__VERSION__ = '0.6.6'
 
 # 6E invoke-virtual 110
 # 6F invoke-supper

--- a/apkutils/axml/arscparser.py
+++ b/apkutils/axml/arscparser.py
@@ -168,6 +168,7 @@ class ARSCParser(object):
                     self.resource_configs[package_name][a_res_type].add(
                         a_res_type.config)
 
+                    self.buff.set_idx(header.start+header.header_size)
                     entries = []
                     for j in range(0, a_res_type.entryCount):
                         current_package.mResId = current_package.mResId & 0xffff0000 | j
@@ -181,6 +182,8 @@ class ARSCParser(object):
                             break
 
                         if entry != -1:
+                            self.buff.set_idx(
+                                header.start+a_res_type.entriesStart+entry)
                             ate = ARSCResTableEntry(self.buff, res_id, pc)
                             self.packages[package_name].append(ate)
 

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,11 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
 
     install_requires=[
-        "pyelftools",
-        "cigam",
         "xmltodict",
+        "cigam",
+        "pyelftools",
+        "pyopenssl",
         "anytree",
-        "TextWizard"
+        "TextWizard",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os.path
 
-from apkutils import __VERSION__
 from setuptools import find_packages, setup
 
 
@@ -11,7 +10,7 @@ def read(fname):
 setup(
     name="apkutils",
 
-    version=__VERSION__,
+    version='0.6.6',
 
     description=("Utils for parsing apk."),
     long_description=read('README.rst'),


### PR DESCRIPTION
某些资源里的数据不是连续存储的，符合格式规范，Android也能正常解析运行，但apkutils报错，对比源码发现Android是用header里的偏移计算位置的，而不是假设数据是连续