### PR TITLE
fix: 修改搜索main activity的正则表达式

### DIFF
--- a/apkutils/__init__.py
+++ b/apkutils/__init__.py
@@ -72,10 +72,10 @@ class APK:
 
     def _init_main_activity(self):
         mani = self.get_mini_mani()
-        ptn = r'<activity android:name="([^"]*?)"[^<>]*?>.*?<action android:name="android.intent.action.MAIN">.*?</activity>'
+        ptn = r'<activity(.*?)android:name="([^"]*?)"[^<>]*?>.*?<action android:name="android.intent.action.MAIN">.*?</activity>'
         result = re.search(ptn, mani)
         if result:
-            self.main_activity = result.groups()[0]
+            self.main_activity = result.groups()[1]
 
     def get_application(self):
         if not self.application:


### PR DESCRIPTION
```xml
<activity
    android:label="@string/app_name"
    android:name=".MainActivity"
    android:theme="@style/AppTheme.NoActionBar">
    <intent-filter>
        <action android:name="android.intent.action.MAIN" />

        <category android:name="android.intent.category.LAUNCHER" />
    </intent-filter>
</activity>
```
大部分apk的manifest文件activity标签中 `android:name` 的位置不一定是第一个，如上所示。所以把activity后面的空格改为通配符`(.*?)`。